### PR TITLE
My rocks unified

### DIFF
--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -1,45 +1,73 @@
-import { useState } from 'react'
-import { BrowserRouter, Route, Routes } from "react-router-dom"
-import { Authorized } from "./Authorized"
-import { Login } from "../pages/Login.jsx"
-import Home from "../pages/Home"
-import { RockForm } from "./RockForm.jsx"
-import { RockList } from "./RockList.jsx"
-import { Register } from '../pages/Register.jsx'
-
+import { useState } from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Authorized } from "./Authorized";
+import { Login } from "../pages/Login.jsx";
+import Home from "../pages/Home";
+import { RockForm } from "./RockForm.jsx";
+import { RockList } from "./RockList.jsx";
+import { Register } from "../pages/Register.jsx";
 
 export const ApplicationViews = () => {
-    const [rocksState, setRocksState] = useState([{
+  const [rocksState, setRocksState] = useState([
+    {
+      id: 1,
+      name: "Sample",
+      type: {
         id: 1,
-        name: "Sample",
-        type: {
-            id: 1,
-            label: "Volcanic"
-        }
-    }])
+        label: "Volcanic",
+      },
+    },
+  ]);
 
-    const fetchRocksFromAPI = async () => {
-        const response = await fetch("http://localhost:8000/rocks",
-            {
-                headers: {
-                    Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
-                }
-            })
-        const rocks = await response.json()
-        setRocksState(rocks)
+  const fetchRocksFromAPI = async (showAll) => {
+    let url = "http://localhost:8000/rocks";
+
+    if (showAll !== true) {
+      url = "http://localhost:8000/rocks?owner=current";
     }
 
-    return <BrowserRouter>
-        <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
-            <Route element={<Authorized />}>
-                <Route path="/" element={<Home />} />
-                {/* Passing a boolean prop to signal if the user wants to view only rocks they own*/}
-                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} showAll={true}/>} /> 
-                <Route path="/create" element={<RockForm fetchRocks={fetchRocksFromAPI} />} />
-                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} showAll={false}/>
-            </Route>
-        </Routes>
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Token ${
+          JSON.parse(localStorage.getItem("rock_token")).token
+        }`,
+      },
+    });
+    const rocks = await response.json();
+    setRocksState(rocks);
+  };
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route element={<Authorized />}>
+          <Route path="/" element={<Home />} />
+          {/* Passing a boolean prop to signal if the user wants to view only rocks they own*/}
+          <Route
+            path="/allrocks"
+            element={
+              <RockList
+                rocks={rocksState}
+                fetchRocks={fetchRocksFromAPI}
+                showAll={true}
+              />
+            }
+          />
+          <Route
+            path="/create"
+            element={<RockForm fetchRocks={fetchRocksFromAPI} />}
+          />
+          <Route
+            path="/mine"
+            element={
+              <RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />
+            }
+            showAll={false}
+          />
+        </Route>
+      </Routes>
     </BrowserRouter>
-}
+  );
+};

--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -35,9 +35,10 @@ export const ApplicationViews = () => {
             <Route path="/register" element={<Register />} />
             <Route element={<Authorized />}>
                 <Route path="/" element={<Home />} />
-                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                {/* Passing a boolean prop to signal if the user wants to view only rocks they own*/}
+                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} showAll={true}/>} /> 
                 <Route path="/create" element={<RockForm fetchRocks={fetchRocksFromAPI} />} />
-                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} showAll={false}/>
             </Route>
         </Routes>
     </BrowserRouter>

--- a/src/components/RockList.jsx
+++ b/src/components/RockList.jsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/prop-types */
 import { useEffect } from "react";
 
-export const RockList = ({ rocks, fetchRocks }) => {
+export const RockList = ({ rocks, fetchRocks, showAll }) => {
   useEffect(() => {
-    fetchRocks();
-  }, []);
+    fetchRocks(showAll);
+  }, [showAll]);
 
   const displayRocks = () => {
     if (rocks && rocks.length) {

--- a/src/components/RockList.jsx
+++ b/src/components/RockList.jsx
@@ -19,6 +19,34 @@ export const RockList = ({ rocks, fetchRocks, showAll }) => {
           <div>
             In the collection of {rock.user?.first_name} {rock.user?.last_name}
           </div>
+          {showAll ? ( 
+            ""
+          ) : (
+            <div>
+              <button
+                className="btn-delete"
+                onClick={async () => {
+                  const response = await fetch(
+                    `http://localhost:8000/rocks/${rock.id}`,
+                    {
+                      method: "DELETE",
+                      headers: {
+                        Authorization: `Token ${
+                          JSON.parse(localStorage.getItem("rock_token")).token
+                        }`,
+                      },
+                    }
+                  );
+
+                  if (response.status === 204) {
+                    fetchRocks(showAll);
+                  }
+                }}
+              >
+                DELETE
+              </button>
+            </div>
+          )}
         </div>
       ));
     }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+
+@layer components {
+    .btn-delete {
+      @apply bg-red-800/60 hover:bg-red-600/90 text-white font-bold py-2 px-4 border-slate-950/50 border-2 hover:border-white rounded-2xl;
+    }
+  }


### PR DESCRIPTION
# "Show Mine" list implemented and including a delete button

## Steps to Achieve Outcome:
- Added a "showAll" boolean prop to the `ApplicationViews` parent component in the `/allrocks` and `/mine` routes to be passed down to the `RockList` component.
- In the `RockList` component, `showAll` is now being passed as an argument into `fetchRocks`, and as a variable in the useEffect dependency array.  
- Added a conditional statement to `fetchRocksFromAPI` evaluating `showAll`.  If `showAll` is false, `http://localhost:8000/rocks?owner=current` is fetched instead of `http://localhost:8000/rocks`
- Using a ternary that evaluates `showAll`, renders a delete button if false.
- When the button is clicked, if the DELETE is successful, `fetchRocks(showAll)` is invoked, re-rendering the page.

## How to Test:
1. Pull the 'my-rocks-unified' branch associated with this PR.
2. Ensure your API is running.
3. Use `npm run dev` in the root directory of the client
4. In your browser, navigate to `http://localhost:5173/` 
5. Evaluate the difference between the "My Rocks" view and the "All Rocks" view to verify that only rocks that belong to the logged in user are displaying.
6. Test the delete function by deleting a rock (create one first if the user doesn't have any).